### PR TITLE
remove python version 3.6

### DIFF
--- a/gprior.py
+++ b/gprior.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python
 
 from gprior.modules import *
 

--- a/process_postgap.py
+++ b/process_postgap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python
 
 import sys
 import os


### PR DESCRIPTION
We need to remove python version 3.6 since it will report error if the user have 3.7